### PR TITLE
chore: add one to price tick math magic numbers, to ensure strict upp…

### DIFF
--- a/src/libraries/PriceTickMath.sol
+++ b/src/libraries/PriceTickMath.sol
@@ -36,10 +36,10 @@ library PriceTickMath {
 
     /**
         @notice MIN_PRICE <= price <= MAX_PRICE
-        @dev Computed as getPriceAtTick(MIN_PRICE_TICK) and getPriceAtTick(MAX_PRICE_TICK)
+        @dev Computed as getPriceAtTickOver(MIN_PRICE_TICK) and getPriceAtTickOver(MAX_PRICE_TICK)
      */
     // solhint-disable-next-line private-vars-leading-underscore
-    uint256 internal constant MIN_PRICE = 16777401;
+    uint256 internal constant MIN_PRICE = 16777402;
     // solhint-disable-next-line private-vars-leading-underscore
     uint256 internal constant MAX_PRICE = 6901670243043972986255200373924895033102563660822112080378694173663318;
 
@@ -284,30 +284,30 @@ library PriceTickMath {
     function _getPriceAtAbsTickOver(uint256 absTick) private pure returns (uint256 priceX128) {
         unchecked {
             priceX128 = absTick & 0x1 != 0 ? 0xfff97272373d413259a46990580e213a : 0x100000000000000000000000000000000;
-            if (absTick & 0x2 != 0) priceX128 = (priceX128 * 0xfff2e50f5f656932ef12357cf3c7fdcc) >> 128;
-            if (absTick & 0x4 != 0) priceX128 = (priceX128 * 0xffe5caca7e10e4e61c3624eaa0941cd0) >> 128;
-            if (absTick & 0x8 != 0) priceX128 = (priceX128 * 0xffcb9843d60f6159c9db58835c926644) >> 128;
-            if (absTick & 0x10 != 0) priceX128 = (priceX128 * 0xff973b41fa98c081472e6896dfb254c0) >> 128;
-            if (absTick & 0x20 != 0) priceX128 = (priceX128 * 0xff2ea16466c96a3843ec78b326b52861) >> 128;
-            if (absTick & 0x40 != 0) priceX128 = (priceX128 * 0xfe5dee046a99a2a811c461f1969c3053) >> 128;
-            if (absTick & 0x80 != 0) priceX128 = (priceX128 * 0xfcbe86c7900a88aedcffc83b479aa3a4) >> 128;
-            if (absTick & 0x100 != 0) priceX128 = (priceX128 * 0xf987a7253ac413176f2b074cf7815e54) >> 128;
-            if (absTick & 0x200 != 0) priceX128 = (priceX128 * 0xf3392b0822b70005940c7a398e4b70f3) >> 128;
-            if (absTick & 0x400 != 0) priceX128 = (priceX128 * 0xe7159475a2c29b7443b29c7fa6e889d9) >> 128;
-            if (absTick & 0x800 != 0) priceX128 = (priceX128 * 0xd097f3bdfd2022b8845ad8f792aa5826) >> 128;
-            if (absTick & 0x1000 != 0) priceX128 = (priceX128 * 0xa9f746462d870fdf8a65dc1f90e061e5) >> 128;
-            if (absTick & 0x2000 != 0) priceX128 = (priceX128 * 0x70d869a156d2a1b890bb3df62baf32f7) >> 128;
-            if (absTick & 0x4000 != 0) priceX128 = (priceX128 * 0x31be135f97d08fd981231505542fcfa6) >> 128;
-            if (absTick & 0x8000 != 0) priceX128 = (priceX128 * 0x9aa508b5b7a84e1c677de54f3e99bc9) >> 128;
-            if (absTick & 0x10000 != 0) priceX128 = (priceX128 * 0x5d6af8dedb81196699c329225ee605) >> 128;
-            if (absTick & 0x20000 != 0) priceX128 = (priceX128 * 0x2216e584f5fa1ea926041bedfe98) >> 128;
-            if (absTick & 0x40000 != 0) priceX128 = (priceX128 * 0x48a170391f7dc42444e8fa3) >> 128;
-            if (absTick & 0x80000 != 0) priceX128 = (priceX128 * 0x149b34ee7ac263) >> 128;
+            if (absTick & 0x2 != 0) priceX128 = ((priceX128 * 0xfff2e50f5f656932ef12357cf3c7fdcc) >> 128) + 1;
+            if (absTick & 0x4 != 0) priceX128 = ((priceX128 * 0xffe5caca7e10e4e61c3624eaa0941cd0) >> 128) + 1;
+            if (absTick & 0x8 != 0) priceX128 = ((priceX128 * 0xffcb9843d60f6159c9db58835c926644) >> 128) + 1;
+            if (absTick & 0x10 != 0) priceX128 = ((priceX128 * 0xff973b41fa98c081472e6896dfb254c0) >> 128) + 1;
+            if (absTick & 0x20 != 0) priceX128 = ((priceX128 * 0xff2ea16466c96a3843ec78b326b52861) >> 128) + 1;
+            if (absTick & 0x40 != 0) priceX128 = ((priceX128 * 0xfe5dee046a99a2a811c461f1969c3053) >> 128) + 1;
+            if (absTick & 0x80 != 0) priceX128 = ((priceX128 * 0xfcbe86c7900a88aedcffc83b479aa3a4) >> 128) + 1;
+            if (absTick & 0x100 != 0) priceX128 = ((priceX128 * 0xf987a7253ac413176f2b074cf7815e54) >> 128) + 1;
+            if (absTick & 0x200 != 0) priceX128 = ((priceX128 * 0xf3392b0822b70005940c7a398e4b70f3) >> 128) + 1;
+            if (absTick & 0x400 != 0) priceX128 = ((priceX128 * 0xe7159475a2c29b7443b29c7fa6e889d9) >> 128) + 1;
+            if (absTick & 0x800 != 0) priceX128 = ((priceX128 * 0xd097f3bdfd2022b8845ad8f792aa5826) >> 128) + 1;
+            if (absTick & 0x1000 != 0) priceX128 = ((priceX128 * 0xa9f746462d870fdf8a65dc1f90e061e5) >> 128) + 1;
+            if (absTick & 0x2000 != 0) priceX128 = ((priceX128 * 0x70d869a156d2a1b890bb3df62baf32f7) >> 128) + 1;
+            if (absTick & 0x4000 != 0) priceX128 = ((priceX128 * 0x31be135f97d08fd981231505542fcfa6) >> 128) + 1;
+            if (absTick & 0x8000 != 0) priceX128 = ((priceX128 * 0x9aa508b5b7a84e1c677de54f3e99bc9) >> 128) + 1;
+            if (absTick & 0x10000 != 0) priceX128 = ((priceX128 * 0x5d6af8dedb81196699c329225ee605) >> 128) + 1;
+            if (absTick & 0x20000 != 0) priceX128 = ((priceX128 * 0x2216e584f5fa1ea926041bedfe98) >> 128) + 1;
+            if (absTick & 0x40000 != 0) priceX128 = ((priceX128 * 0x48a170391f7dc42444e8fa3) >> 128) + 1;
+            if (absTick & 0x80000 != 0) priceX128 = ((priceX128 * 0x149b34ee7ac263) >> 128) + 1;
         }
     }
 
     /**
-        @notice Returns Q128.128 price at `absTick`. Always underestimates. Assumes absTick < MAX_PRICE_TICK
+        @notice Returns Q128.128 price at `absTick`. 
         @dev Always underestimates relatively to the ground truth value.
         @param absTick Price in log-space.
         @dev It is assumed that `absTick` <= MAX_PRICE_TICK.


### PR DESCRIPTION
- Added 1 to each magic number in `PriceTickMath.getPriceAtTickOver`, to ensure it is a strict upper bound to the true price