### PR TITLE
Chore: reverting stateming changes 

### DIFF
--- a/src/pools/SovereignPool.sol
+++ b/src/pools/SovereignPool.sol
@@ -1048,9 +1048,9 @@ contract SovereignPool is ISovereignPool, ReentrancyGuard {
                 amountInUsed,
                 _swapCallbackContext
             );
+        } else {
+            token.safeTransferFrom(msg.sender, sovereignVault, amountInUsed);
         }
-
-        token.safeTransferFrom(msg.sender, sovereignVault, amountInUsed);
 
         uint256 amountInReceived = token.balanceOf(sovereignVault) - preBalance;
 

--- a/test/base/SovereignPoolBase.t.sol
+++ b/test/base/SovereignPoolBase.t.sol
@@ -167,6 +167,7 @@ contract SovereignPoolBase is Base, SovereignPoolDeployer {
             vm.prank(vault);
             IERC20(_tokenIn).transfer(DUMP_ADDRESS, amountToRemove);
         }
+        IERC20(_tokenIn).transfer(vault, amountIn);
     }
 
     function _generateDefaultConstructorArgs()


### PR DESCRIPTION
Reverting statemind changes about transferring token to sovereign vault by pool itself, rather than relying on swapper in swapcallback